### PR TITLE
Using the metadata inside of the frontend json to get video details

### DIFF
--- a/src/main/java/nl/thedutchmc/betterplayer/commands/defaultcommands/PlayCommandExecutor.java
+++ b/src/main/java/nl/thedutchmc/betterplayer/commands/defaultcommands/PlayCommandExecutor.java
@@ -22,6 +22,7 @@ import nl.thedutchmc.betterplayer.search.YoutubeSearch;
 import nl.thedutchmc.httplib.Http;
 import nl.thedutchmc.httplib.Http.RequestMethod;
 import nl.thedutchmc.httplib.Http.ResponseObject;
+import nl.thedutchmc.betterplayer.search.*;
 
 public class PlayCommandExecutor implements CommandExecutor {
 
@@ -104,9 +105,9 @@ public class PlayCommandExecutor implements CommandExecutor {
 		}*/
 		
 		//Perform a search via YT's frontend
-		String videoId = new YoutubeSearch().search(parameters.getArgs());
+		VideoDetails details = new YoutubeSearch().search(parameters.getArgs());
 		
-		//Get details about the video found
+		/*///Get details about the video found
 		HashMap<String, String> urlParameters = new HashMap<>();
 		urlParameters.put("key", apiKey);
 		urlParameters.put("part", "snippet,contentDetails");
@@ -146,37 +147,36 @@ public class PlayCommandExecutor implements CommandExecutor {
 		for(Object oItem : items) {
 			JSONObject jsonItem = (JSONObject) oItem;
 			JSONObject snippet = jsonItem.getJSONObject("snippet");
-			
-			String title = snippet.getString("title");
-			String thumbnailUrl = snippet.getJSONObject("thumbnails").getJSONObject("default").getString("url");
+			*/
+			//String title = snippet.getString("title");
+			//String thumbnailUrl = snippet.getJSONObject("thumbnails").getJSONObject("default").getString("url");
 			User author = jda.getUserById(parameters.getSenderId());
-			String channel = snippet.getString("channelTitle");
+			//String channel = snippet.getString("channelTitle");
 			
-			JSONObject contentDetails = jsonItem.getJSONObject("contentDetails");
-			String duration = contentDetails.getString("duration").replace("PT", "").replace("M", ":").replace("S", "");
+			//JSONObject contentDetails = jsonItem.getJSONObject("contentDetails");
+			//String duration = contentDetails.getString("duration").replace("PT", "").replace("M", ":").replace("S", "");
 			
 			QueueManager qm = betterPlayer.getBetterAudioManager().getQueueManager();
 			
-			QueueItem qi = new QueueItem(videoId, title);
+			QueueItem qi = new QueueItem(details.Id, details.Title);
 			qm.addToQueue(qi, parameters.getGuildId());
 			
 			//System.out.println(betterPlayer.getBetterAudioManager().isPlaying(parameters.getGuildId()));
 			
 			if(!betterPlayer.getBetterAudioManager().isPlaying(parameters.getGuildId())) {
-				betterPlayer.getBetterAudioManager().loadTrack(videoId, parameters.getGuildId());
+				betterPlayer.getBetterAudioManager().loadTrack(details.Id, parameters.getGuildId());
 			}
 			
 			EmbedBuilder eb = new EmbedBuilder()
-					.setTitle(title)
-					.setThumbnail(thumbnailUrl)
+					.setTitle(details.Title)
+					.setThumbnail(details.Thumbnail)
 					.setColor(Color.GRAY)
 					.setAuthor("Adding to the queue", "https://google.com", author.getEffectiveAvatarUrl())
-					.addField("Channel", channel, true)
-					.addField("Duration", duration, true)
+					.addField("Channel", details.Channel, true)
+					.addField("Duration", details.Duration, true)
 					.setFooter("Brought to you by BetterPlayer. Powered by YouTube", "https://archive.org/download/mx-player-icon/mx-player-icon.png");
 			
 			senderChannel.sendMessage(eb.build()).queue();
-			break;
-		}
+			//break;
 	}
 }

--- a/src/main/java/nl/thedutchmc/betterplayer/search/VideoDetails.java
+++ b/src/main/java/nl/thedutchmc/betterplayer/search/VideoDetails.java
@@ -1,0 +1,9 @@
+package nl.thedutchmc.betterplayer.search;
+
+public class VideoDetails {
+    public String Id;
+    public String Thumbnail;
+    public String Title;
+    public String Channel;
+    public String Duration;
+}

--- a/src/main/java/nl/thedutchmc/betterplayer/search/YoutubeSearch.java
+++ b/src/main/java/nl/thedutchmc/betterplayer/search/YoutubeSearch.java
@@ -15,7 +15,7 @@ import nl.thedutchmc.httplib.Http.ResponseObject;
 
 public class YoutubeSearch {
 	
-	public String search(String[] searchTerms) {
+	public VideoDetails search(String[] searchTerms) {
 		//Join the search terms together with '+' as delimiter.
 		String q = String.join("+", searchTerms);
 		
@@ -61,7 +61,8 @@ public class YoutubeSearch {
 				.getJSONObject("sectionListRenderer")
 				.getJSONArray("contents");
 				
-		String videoId = "";
+		//String videoId = "";
+		VideoDetails details = new VideoDetails();
 		outerJsonParseLoop: for(Object o : contentsChild) {
 			JSONObject oJson = (JSONObject) o;
 			JSONArray musicShelfRendererContents = oJson
@@ -70,19 +71,44 @@ public class YoutubeSearch {
 			
 			for(Object o1 : musicShelfRendererContents) {
 				JSONObject o1Json = (JSONObject) o1;
-				videoId = o1Json
-						.getJSONObject("musicResponsiveListItemRenderer")
+
+				JSONObject renderer = o1Json.getJSONObject("musicResponsiveListItemRenderer");
+				details.Id = renderer
 						.getJSONObject("overlay")
 						.getJSONObject("musicItemThumbnailOverlayRenderer")
 						.getJSONObject("content")
 						.getJSONObject("musicPlayButtonRenderer")
 						.getJSONObject("playNavigationEndpoint")
 						.getJSONObject("watchEndpoint")
-						.getString("videoId");				
+						.getString("videoId");
+
+				JSONArray textParts = renderer
+						.getJSONArray("flexColumns")
+						.getJSONObject(0)
+						.getJSONObject("musicResponsiveListItemFlexColumnRenderer")
+						.getJSONObject("text")
+						.getJSONArray("runs");
+				details.Title = textParts.getJSONObject(0).getString("text");
+
+				textParts = renderer
+						.getJSONArray("flexColumns")
+						.getJSONObject(1)
+						.getJSONObject("musicResponsiveListItemFlexColumnRenderer")
+						.getJSONObject("text")
+						.getJSONArray("runs");
+				details.Channel = textParts.getJSONObject(2).getString("text");
+				details.Duration = textParts.getJSONObject(6).getString("text");
+
+				JSONArray thumbnails = renderer
+						.getJSONObject("thumbnail")
+						.getJSONObject("musicThumbnailRenderer")
+						.getJSONObject("thumbnail")
+						.getJSONArray("thumbnails");
+				details.Thumbnail = thumbnails.getJSONObject(0).getString("url");
 				break outerJsonParseLoop;
 			}
 		}
 			
-		return videoId;
+		return details;
 	}
 }


### PR DESCRIPTION
This PR tries to use the metadata inside of the json found on the frontend to get all information about a video. This way there are no calls made to the Youtube Data API.

It needs some cleaning up though.